### PR TITLE
Add missing “boost-variant” dependency

### DIFF
--- a/vcpkg/packages.txt
+++ b/vcpkg/packages.txt
@@ -7,4 +7,5 @@ boost-filesystem
 boost-optional
 boost-container-hash
 boost-thread
+boost-variant
 openssl


### PR DESCRIPTION
Fix build issue: `'boost/variant.hpp' file not found `